### PR TITLE
Update gobierto_budgets_data dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "gobierto_data", git: "https://github.com/PopulateTools/gobierto_data.git"
+gem "gobierto_budgets_data", git: "https://github.com/PopulateTools/gobierto_budgets_data.git"
 gem "ine-places"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
-  remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: ae3bb71c5988df7947817782798630cfa7d96f01
+  remote: https://github.com/PopulateTools/gobierto_budgets_data.git
+  revision: 7db1fa4d63f08ca30d334255469144bdbc246673
   specs:
-    gobierto_data (0.1.0)
+    gobierto_budgets_data (0.1.0)
       actionpack
       activesupport
       aws-sdk-s3
@@ -106,7 +106,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  gobierto_data!
+  gobierto_budgets_data!
   ine-places
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ETL scripts for Gobierto Budgets Comparator https://presupuestos.gobierto.es
 
 Edit `.env.example` and copy it to `.env` or `.rbenv-vars` with the expected values.
 
-This repository relies heavily in [gobierto_data](https://github.com/PopulateTools/gobierto_data)
+This repository relies heavily in [gobierto_budgets_data](https://github.com/PopulateTools/gobierto_budgets_data)
 
 ## Available operations
 


### PR DESCRIPTION
Related to PopulateTools/issues#1352

This PR updates the gems dependency to point `gobierto_budgets_data` instead of `gobierto_data`